### PR TITLE
Begin Metal Renderer skeleton

### DIFF
--- a/Sources/CocoaBridge.h
+++ b/Sources/CocoaBridge.h
@@ -24,3 +24,4 @@ Boolean SetCursorNamed(CFStringRef cursorName, float scale);
 int RunCocoaDialog(CFStringRef nibName, CFMutableDictionaryRef valuesDict, CFStringRef controllerClassName);
 void LWOpenURL(CFStringRef urlString);
 void SetRefMenuIcons(MenuRef theMenu);
+void *LWCreateMetalView(void *windowRef);

--- a/Sources/CocoaBridge.m
+++ b/Sources/CocoaBridge.m
@@ -720,3 +720,21 @@ void SetRefMenuIcons(MenuRef theMenu) {
     [myPool release];
 }
 
+void *LWCreateMetalView(void *windowRef) {
+    CocoaInit();
+    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
+    MTKView *result = nil;
+    @try {
+        NSWindow *theWindow = [[LWWindowManager sharedInstance] windowForWindowRef:windowRef];
+        if (theWindow) {
+            result = [[[MTKView alloc] initWithFrame:[[theWindow contentView] bounds] device:MTLCreateSystemDefaultDevice()] autorelease];
+            [result setAutoresizingMask:(NSViewWidthSizable | NSViewHeightSizable)];
+            [[theWindow contentView] addSubview:result];
+        }
+    } @catch (NSException *exception) {
+        NSLog(@"LWCreateMetalView %@", exception);
+    }
+    [pool release];
+    return result;
+}
+

--- a/Sources/U3MetalRenderer.h
+++ b/Sources/U3MetalRenderer.h
@@ -1,0 +1,13 @@
+#import <Foundation/Foundation.h>
+#import <MetalKit/MetalKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface U3MetalRenderer : NSObject
+
+- (instancetype)initWithView:(MTKView *)view;
+- (void)draw;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/U3MetalRenderer.m
+++ b/Sources/U3MetalRenderer.m
@@ -1,0 +1,42 @@
+#import "U3MetalRenderer.h"
+
+@implementation U3MetalRenderer {
+    __weak MTKView *_view;
+    id<MTLDevice> _device;
+    id<MTLCommandQueue> _commandQueue;
+}
+
+- (instancetype)initWithView:(MTKView *)view {
+    self = [super init];
+    if (self) {
+        _view = view;
+        _device = MTLCreateSystemDefaultDevice();
+        _view.device = _device;
+        _commandQueue = [_device newCommandQueue];
+    }
+    return self;
+}
+
+- (void)draw {
+    @autoreleasepool {
+        id<CAMetalDrawable> drawable = [_view currentDrawable];
+        if (!drawable) {
+            return;
+        }
+        id<MTLCommandBuffer> commandBuffer = [_commandQueue commandBuffer];
+        [commandBuffer presentDrawable:drawable];
+        [commandBuffer commit];
+    }
+}
+
+@end
+
+static U3MetalRenderer *sRenderer = nil;
+
+void U3InitMetalRenderer(MTKView *view) {
+    sRenderer = [[U3MetalRenderer alloc] initWithView:view];
+}
+
+void U3MetalRenderFrame(void) {
+    [sRenderer draw];
+}

--- a/Sources/UltimaGraphics.h
+++ b/Sources/UltimaGraphics.h
@@ -60,4 +60,14 @@ Boolean SetupGameToDisplay(void);
 Boolean SetupFrameToDisplay(void);
 void DrawGamePortToMain(Boolean);
 
+#ifdef __APPLE__
+#ifdef __OBJC__
+@class MTKView;
+#else
+typedef void MTKView;
+#endif
+void U3InitMetalRenderer(MTKView *view);
+void U3MetalRenderFrame(void);
+#endif
+
 #endif /* UltimaGraphics_h */

--- a/Sources/UltimaMacIF.c
+++ b/Sources/UltimaMacIF.c
@@ -832,12 +832,14 @@ void WindowInit(short which) {
         SizeWindow(gMainWindow, blkSiz * 40, blkSiz * 24, FALSE);
     PlaceWindow();
     ForceAllOnScreen();
-    /*
     // put this boolean YES into info.plist: NSHighResolutionCapable
     Rect windowRect;
-    if (noErr == GetWindowBounds(gMainWindow, kWindowContentRgn, &windowRect))
+    if (noErr == GetWindowBounds(gMainWindow, kWindowContentRgn, &windowRect)) {
         WrapCarbonWindowInCocoa(gMainWindow, windowRect.left, windowRect.top, windowRect.right-windowRect.left, windowRect.bottom-windowRect.top);
-*/
+        void *mtk = LWCreateMetalView(gMainWindow);
+        if (mtk)
+            U3InitMetalRenderer((MTKView *)mtk);
+    }
     ShowWindow(gMainWindow);
     SetPortWindowPort(gMainWindow);
     UpdateRgn = NewRgn();

--- a/Ultima3_Prefix.pch
+++ b/Ultima3_Prefix.pch
@@ -3,3 +3,4 @@
 //
 
 #include <Carbon/Carbon.h>
+#import <MetalKit/MetalKit.h>


### PR DESCRIPTION
## Summary
- add a simple Metal renderer class
- expose functions to initialize and draw with Metal
- wrap Carbon windows with a Metal view
- include MetalKit headers via prefix

## Testing
- `clang -fobjc-arc -c Sources/U3MetalRenderer.m` *(fails: `-fobjc-arc is not supported on platforms using the legacy runtime`)*

------
https://chatgpt.com/codex/tasks/task_e_68513d0c60048329a807c17b303e5f26