### PR TITLE
Remove unused AVFoundation imports

### DIFF
--- a/Sources/UltimaGraphics.c
+++ b/Sources/UltimaGraphics.c
@@ -14,7 +14,6 @@
 #import "UltimaSpellCombat.h"
 #import "UltimaText.h"
 
-#import <AVFoundation/AVFoundation.h>
 
 extern OSErr            gError;
 extern WindowPtr        gMainWindow, gShroudWindow;

--- a/Sources/UltimaMain.c
+++ b/Sources/UltimaMain.c
@@ -17,7 +17,6 @@
 #import "UltimaSpellCombat.h"
 #import "UltimaText.h"
 
-#import <AVFoundation/AVFoundation.h>
 
 extern short    gSongCurrent, gSongNext, gSongPlaying;
 extern Boolean  gSoundIncapable, gMusicIncapable;


### PR DESCRIPTION
## Summary
- remove leftover AVFoundation includes from UltimaMain.c
- remove leftover AVFoundation includes from UltimaGraphics.c

## Testing
- `clang -fsyntax-only -x c -I./Sources Sources/UltimaMain.c` *(fails: unknown type name 'Boolean')*
- `clang -fsyntax-only -x c -I./Sources Sources/UltimaGraphics.c` *(fails: unknown type name 'Boolean')*


------
https://chatgpt.com/codex/tasks/task_e_6851bd058b7c832984baa7de3d9c9f17