### PR TITLE
Fix missing NumToString declaration

### DIFF
--- a/Sources/CarbonShunts.h
+++ b/Sources/CarbonShunts.h
@@ -6,6 +6,8 @@
 #ifndef CarbonShunts_h
 #define CarbonShunts_h
 
+#include <Carbon/Carbon.h>
+
 void ForceUpdateMain(void);
 void LWSetArrowCursor(void);
 void LWSetDialogPort(DialogPtr theDialog);

--- a/Sources/UltimaSpellCombat.c
+++ b/Sources/UltimaSpellCombat.c
@@ -1,5 +1,6 @@
 // Spell & Combat routines
 
+#include <Carbon/Carbon.h>
 #import "UltimaSpellCombat.h"
 
 #import "UltimaIncludes.h"


### PR DESCRIPTION
## Summary
- include Carbon headers for classic Mac definitions
- ensure `UltimaSpellCombat.c` includes Carbon before its own header

## Testing
- `clang -c Sources/UltimaSpellCombat.c` *(fails: unknown type name 'Boolean' etc. The repo depends on the macOS SDK which isn't available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_6851c0e960008329b30972b584de213b