### PR TITLE
Fix missing Carbon shims

### DIFF
--- a/Sources/CarbonShunts.h
+++ b/Sources/CarbonShunts.h
@@ -29,4 +29,19 @@ Boolean GoodHandle(Handle h);
 void LWBlockZero(void *destPtr, Size byteCount);
 void DefineDefaultItem(DialogPtr theDialog, short item);
 
+// Older Carbon APIs like BlockMove() and ObscureCursor() are not available
+// when compiling for modern macOS SDKs. Provide simple shims so legacy source
+// files continue to build. These implementations are minimal but sufficient for
+// the game's needs.
+#ifndef BlockMove
+#include <string.h>
+static inline void BlockMove(const void *src, void *dst, Size len) {
+    memmove(dst, src, (size_t)len);
+}
+#endif
+
+#ifndef ObscureCursor
+static inline void ObscureCursor(void) { HideCursor(); }
+#endif
+
 #endif /* CarbonShunts_h */

--- a/Sources/UltimaSpellCombat.c
+++ b/Sources/UltimaSpellCombat.c
@@ -4,6 +4,7 @@
 #import "UltimaSpellCombat.h"
 
 #import "UltimaIncludes.h"
+#import "CarbonShunts.h"
 #import "CocoaBridge.h"
 #import "UltimaAutocombat.h"
 #import "UltimaDngn.h"


### PR DESCRIPTION
## Summary
- add simple shims for BlockMove and ObscureCursor in CarbonShunts
- include CarbonShunts in UltimaSpellCombat for shim access

## Testing
- `clang -fsyntax-only -x objective-c Sources/UltimaSpellCombat.c` *(fails: 'Carbon/Carbon.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851c807cfd48329979f6669c176c03e