### PR TITLE
Fix missing LineTo stub for macOS builds

### DIFF
--- a/Sources/CarbonShunts.h
+++ b/Sources/CarbonShunts.h
@@ -77,6 +77,9 @@ static inline short StringWidth(const unsigned char *str) {
 #ifndef MoveTo
 static inline void MoveTo(short h, short v) { (void)h; (void)v; }
 #endif
+#ifndef LineTo
+static inline void LineTo(short h, short v) { (void)h; (void)v; }
+#endif
 #ifndef DrawString
 static inline void DrawString(const unsigned char *str) { (void)str; }
 #endif


### PR DESCRIPTION
## Summary
- ensure CarbonShunts defines `LineTo` when unavailable

## Testing
- `clang test_line.c -I Sources -c`

------
https://chatgpt.com/codex/tasks/task_e_68530417b30c8329b984bcca00143b60