### PR TITLE
Fix PicHandle typedef for non-mac builds

### DIFF
--- a/Sources/CarbonShunts.h
+++ b/Sources/CarbonShunts.h
@@ -272,7 +272,15 @@ typedef void *CursHandle;
 #endif
 
 #ifndef PicHandle
-typedef void *PicHandle;
+/*
+ * Match the historical QuickDraw definition so builds that
+ * provide their own Picture types do not conflict with this
+ * lightweight shim. The actual structure layout is irrelevant
+ * for our purposes, so we only forward declare it here.
+ */
+typedef struct Picture Picture;
+typedef Picture *PicPtr;
+typedef PicPtr *PicHandle;
 #endif
 
 #ifndef Random


### PR DESCRIPTION
## Summary
- correct PicHandle definition to mirror QuickDraw

## Testing
- `clang -fsyntax-only /tmp/test.c -I. -I Sources`
- `clang -U__APPLE__ -fsyntax-only /tmp/test.c -I. -I Sources`


------
https://chatgpt.com/codex/tasks/task_e_68530774e1b883299c6dc6f4073da29d