### PR TITLE
Fix ReleaseResource redefinition on macOS

### DIFF
--- a/Sources/CarbonShunts.h
+++ b/Sources/CarbonShunts.h
@@ -315,8 +315,10 @@ static inline PicHandle GetPicture(short id) { (void)id; return NULL; }
 #ifndef DrawPicture
 static inline void DrawPicture(PicHandle pic, const Rect *r) { (void)pic; (void)r; }
 #endif
+#ifndef __APPLE__
 #ifndef ReleaseResource
 static inline void ReleaseResource(Handle h) { (void)h; }
+#endif
 #endif
 #ifndef GetCursor
 static inline CursHandle GetCursor(short id) { (void)id; return NULL; }


### PR DESCRIPTION
## Summary
- avoid redefining `ReleaseResource` when building on macOS

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6853086d5b8483298432ee8e0623252b