### PR TITLE
Resolve legacy cursor and rectangle usage

### DIFF
--- a/Sources/CarbonShunts.h
+++ b/Sources/CarbonShunts.h
@@ -20,6 +20,11 @@ static inline void OffsetRect(Rect *r, short dh, short dv) {
     r->left += dh; r->right += dh; r->top += dv; r->bottom += dv;
 }
 #endif
+#ifndef InsetRect
+static inline void InsetRect(Rect *r, short dh, short dv) {
+    r->left += dh; r->right -= dh; r->top += dv; r->bottom -= dv;
+}
+#endif
 #ifndef SetGWorld
 static inline void SetGWorld(CGrafPtr port, GDHandle dev) {
     (void)port; (void)dev;
@@ -55,6 +60,9 @@ static inline void BackColor(short c) { (void)c; }
 #endif
 #ifndef PaintRect
 static inline void PaintRect(const Rect *r) { (void)r; }
+#endif
+#ifndef FrameRect
+static inline void FrameRect(const Rect *r) { (void)r; }
 #endif
 #ifndef TextFont
 static inline void TextFont(short font) { (void)font; }
@@ -111,6 +119,9 @@ static inline void LWKillPoly(LWPolyHandle poly) { (void)poly; }
 #define cyanColor    273
 #define magentaColor 137
 #define yellowColor  69
+#endif
+#ifndef watchCursor
+#define watchCursor 4
 #endif
 #ifndef srcCopy
 #define srcCopy     0

--- a/Sources/UltimaGraphics.c
+++ b/Sources/UltimaGraphics.c
@@ -1448,7 +1448,7 @@ void DrawMiniMap(void) {
     gSongCurrent = 10;
     MusicUpdate();
     watchCurs = GetCursor(watchCursor);
-    SetCursor(*watchCurs);
+    SetCursor(watchCurs);
     ForeColor(blackColor);
     mapRect.left = (blkSiz * 12) - (minSize * (gCurMapSize / 2));
     mapRect.right = mapRect.left + (minSize * gCurMapSize);

--- a/Sources/UltimaMacIF.c
+++ b/Sources/UltimaMacIF.c
@@ -679,7 +679,7 @@ void ToolBoxInit(void) {
 #endif
     InitCursor();
     watchCurs = GetCursor(watchCursor);
-    SetCursor(*watchCurs);
+    SetCursor(watchCurs);
 }
 
 void SetUpDragRect(void) {

--- a/Sources/UltimaNewMap.c
+++ b/Sources/UltimaNewMap.c
@@ -438,7 +438,7 @@ void DrawDioramaMap(void) {
     gSongCurrent = 10;
     MusicUpdate();
     watchCurs = GetCursor(watchCursor);
-    SetCursor(*watchCurs);
+    SetCursor(watchCurs);
     ForeColor(blackColor);
     mapRect.left = (blkSiz * 12) - (minSize * 32);
     mapRect.right = mapRect.left + (minSize * gCurMapSize);


### PR DESCRIPTION
## Summary
- fix SetCursor usage for watch cursor handle
- stub InsetRect and FrameRect
- define watchCursor constant

## Testing
- `clang -c Sources/UltimaNewMap.c -I Sources -I .` *(fails: unknown type name 'CFStringRef')*

------
https://chatgpt.com/codex/tasks/task_e_685309a808888329a7009ed85858eb95