### PR TITLE
Fix missing CursHandle type

### DIFF
--- a/Sources/CarbonShunts.h
+++ b/Sources/CarbonShunts.h
@@ -8,6 +8,11 @@
 
 #ifdef __APPLE__
 #include <Carbon/Carbon.h>
+/* Older SDKs removed certain QuickDraw types entirely. Ensure the
+   cursor handle type is available before it is referenced below. */
+#ifndef CursHandle
+typedef void *CursHandle;
+#endif
 #ifndef SetRect
 static inline void SetRect(Rect *r, short l, short t, short rgt, short btm) {
     r->left = l; r->top = t; r->right = rgt; r->bottom = btm;


### PR DESCRIPTION
## Summary
- patch `CarbonShunts.h` to provide a fallback definition for `CursHandle`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68531170300c83298118bfa15697d7bc